### PR TITLE
Add concurrency limit to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: "Publish Documentation to NIST Pages"
 
+concurrency:
+   group: ${{ github.workflow }}
+   cancel-in-progress: false
+
 on: [push, pull_request, delete]
 
 jobs:


### PR DESCRIPTION
Docs4NIST does not handle multiple concurrent runs well; a race condition causes workflow failures.  This small patch limits Docs4NIST runs to one-at-a-time to avoid this.