### PR TITLE
Add cluster membership probability operation

### DIFF
--- a/tests/test_membership_probability.py
+++ b/tests/test_membership_probability.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from AFL.double_agent.Labeler import ClusterMembershipProbability
+
+
+@pytest.mark.unit
+def test_membership_probability(example_dataset1_cluster_result):
+    op = ClusterMembershipProbability(
+        similarity_variable="similarity",
+        labels_variable="labels",
+        output_variable="probs",
+        sample_dim="sample",
+    )
+
+    op.calculate(example_dataset1_cluster_result)
+    probs = op.output["probs"]
+
+    assert probs.dims[0] == "sample"
+    assert np.allclose(probs.sum(dim="cluster"), 1.0)
+    assert probs.shape[0] == example_dataset1_cluster_result.dims["sample"]


### PR DESCRIPTION
Introduced a new ClusterMembershipProbability pipeline operation for deriving soft cluster memberships from similarity data and hard labels. The operation calculates probabilities across clusters for each sample, with optional exclusion of self-similarities

Added unit tests verifying that the probability output sums to one along the cluster dimension and aligns with sample count expectations

Partially addresses #44 
