### PR TITLE
Expand dataset builder UI

### DIFF
--- a/AFL/double_agent/DatasetBuilderDriver.py
+++ b/AFL/double_agent/DatasetBuilderDriver.py
@@ -1,0 +1,105 @@
+import json
+import pathlib
+import uuid
+from importlib.resources import files
+from typing import Any, Dict, Optional
+
+import xarray as xr
+from AFL.automation.APIServer.Driver import Driver  # type: ignore
+from jinja2 import Template
+
+from .dataset_plugins import load_plugins
+
+
+def get_dataset_builder_html() -> str:
+    template_path = (
+        files("AFL.double_agent.driver_templates")
+        .joinpath("dataset_builder")
+        .joinpath("dataset_builder.html")
+    )
+    template = Template(template_path.read_text())
+    return template.render()
+
+
+class DatasetBuilderDriver(Driver):
+    """Driver serving the dataset builder web UI and handling uploads."""
+
+    defaults: Dict[str, Any] = {}
+    defaults["save_path"] = "/tmp"
+
+    static_dirs = {
+        "js": pathlib.Path(__file__).parent / "driver_templates" / "dataset_builder" / "js",
+        "css": pathlib.Path(__file__).parent / "driver_templates" / "dataset_builder" / "css",
+    }
+
+    def __init__(
+        self, name: str = "DatasetBuilderDriver", overrides: Optional[Dict[str, Any]] = None
+    ):
+        Driver.__init__(self, name=name, defaults=self.gather_defaults(), overrides=overrides)
+        self.dataset: Optional[xr.Dataset] = None
+        self.plugins = load_plugins()
+
+    @Driver.unqueued(render_hint="html")
+    def dataset_builder(self, **kwargs):
+        return get_dataset_builder_html()
+
+    @Driver.unqueued()
+    def plugin_list(self, **kwargs):
+        return list(self.plugins.keys())
+
+    @Driver.unqueued()
+    def reset(self, **kwargs):
+        self.dataset = None
+
+    @Driver.unqueued()
+    def get_dataset(self, **kwargs):
+        return self.dataset
+
+    @Driver.unqueued(render_hint="html")
+    def get_dataset_html(self, **kwargs):
+        if self.dataset is None:
+            return "<p>No dataset</p>"
+        return self.dataset._repr_html_()
+
+    @Driver.unqueued()
+    def upload_data(
+        self,
+        plugin: str,
+        filename: str,
+        file_bytes: bytes,
+        dims: str = "{}",
+        coords: str = "{}",
+        **kwargs,
+    ):
+        if plugin not in self.plugins:
+            raise ValueError(f"Unknown plugin {plugin}")
+
+        loader = self.plugins[plugin]
+
+        tmp_path = pathlib.Path(self.config["save_path"]) / f"upload_{uuid.uuid4()}"
+        with open(tmp_path, "wb") as f:
+            f.write(file_bytes)
+
+        try:
+            data = loader(str(tmp_path))
+            dims_map = json.loads(dims)
+            coords_map = json.loads(coords)
+            if dims_map:
+                data = data.rename(dims_map)
+            for name, values in coords_map.items():
+                data = data.assign_coords({name: values})
+
+            if self.dataset is None:
+                self.dataset = data
+            else:
+                try:
+                    self.dataset = xr.concat([self.dataset, data], dim=list(data.dims)[0])
+                except Exception as e:
+                    return {"error": str(e)}
+
+            return {"dims": list(self.dataset.dims), "data_vars": list(self.dataset.data_vars)}
+        finally:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass

--- a/AFL/double_agent/__init__.py
+++ b/AFL/double_agent/__init__.py
@@ -48,3 +48,7 @@ def _get_version():
 
 __version__ = _get_version()
 
+try:
+    from .DatasetBuilderDriver import DatasetBuilderDriver
+except Exception:  # pragma: no cover - optional dependency
+    DatasetBuilderDriver = None  # type: ignore

--- a/AFL/double_agent/dataset_plugins/__init__.py
+++ b/AFL/double_agent/dataset_plugins/__init__.py
@@ -1,0 +1,19 @@
+import importlib
+import pkgutil
+from typing import Callable, Dict
+
+Loader = Callable[[str], 'xr.Dataset']
+
+
+def load_plugins() -> Dict[str, Loader]:
+    """Discover available dataset loader plugins."""
+    plugins: Dict[str, Loader] = {}
+    package = importlib.import_module(__name__)
+    for modinfo in pkgutil.iter_modules(package.__path__):
+        module = importlib.import_module(f"{__name__}.{modinfo.name}")
+        loader = getattr(module, "load", None)
+        extensions = getattr(module, "extensions", [])
+        if callable(loader):
+            for ext in extensions:
+                plugins[ext] = loader
+    return plugins

--- a/AFL/double_agent/dataset_plugins/numpy_loader.py
+++ b/AFL/double_agent/dataset_plugins/numpy_loader.py
@@ -1,0 +1,21 @@
+import numpy as np
+import xarray as xr
+
+extensions = ['.npy', '.npz']
+
+def load(path: str) -> xr.Dataset:
+    """Load NumPy array files into an xarray.Dataset."""
+    if path.endswith('.npy'):
+        arr = np.load(path)
+        if arr.ndim == 1:
+            data = xr.DataArray(arr, dims=['dim_0'])
+        else:
+            dims = [f'dim_{i}' for i in range(arr.ndim)]
+            data = xr.DataArray(arr, dims=dims)
+        return data.to_dataset(name='array')
+    elif path.endswith('.npz'):
+        npz = np.load(path)
+        data_vars = {k: xr.DataArray(v, dims=[f'dim_{i}' for i in range(v.ndim)]) for k, v in npz.items()}
+        return xr.Dataset(data_vars)
+    else:
+        raise ValueError('Unsupported file extension for numpy loader')

--- a/AFL/double_agent/dataset_plugins/pandas_loader.py
+++ b/AFL/double_agent/dataset_plugins/pandas_loader.py
@@ -1,0 +1,12 @@
+import pandas as pd
+import xarray as xr
+
+extensions = ['.csv', '.tsv']
+
+def load(path: str) -> xr.Dataset:
+    """Load CSV/TSV files into an xarray.Dataset."""
+    if path.endswith('.csv'):
+        df = pd.read_csv(path)
+    else:
+        df = pd.read_csv(path, sep='\t')
+    return df.to_xarray()

--- a/AFL/double_agent/dataset_plugins/sasmodels_loader.py
+++ b/AFL/double_agent/dataset_plugins/sasmodels_loader.py
@@ -1,0 +1,13 @@
+import xarray as xr
+import pandas as pd
+
+extensions = ['.ses', '.xml', '.dat']
+
+def load(path: str) -> xr.Dataset:
+    """Load SAS data files using xarray as a placeholder."""
+    # Placeholder: attempt to open as text data
+    try:
+        data = xr.Dataset.from_dataframe(pd.read_csv(path, comment='#', delim_whitespace=True))
+    except Exception:
+        data = xr.Dataset()
+    return data

--- a/AFL/double_agent/dataset_plugins/xarray_loader.py
+++ b/AFL/double_agent/dataset_plugins/xarray_loader.py
@@ -1,0 +1,7 @@
+import xarray as xr
+
+extensions = ['.nc', '.netcdf']
+
+def load(path: str) -> xr.Dataset:
+    """Load NetCDF files using xarray."""
+    return xr.load_dataset(path)

--- a/AFL/double_agent/driver_templates/dataset_builder/css/style.css
+++ b/AFL/double_agent/driver_templates/dataset_builder/css/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+table { border-collapse: collapse; margin-top: 10px; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 4px 6px; }
+pre { background: #f0f0f0; padding: 10px; }

--- a/AFL/double_agent/driver_templates/dataset_builder/dataset_builder.html
+++ b/AFL/double_agent/driver_templates/dataset_builder/dataset_builder.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='UTF-8'>
+  <title>Dataset Builder</title>
+  <link rel='stylesheet' href='static/css/style.css'>
+</head>
+<body>
+  <h2>Dataset Builder</h2>
+  <div>
+    <input type='file' id='file-input' multiple>
+    <button id='add-files-btn'>Add Files</button>
+  </div>
+
+  <table id='file-table'>
+    <thead>
+      <tr>
+        <th>Select</th>
+        <th>Filename</th>
+        <th>Plugin</th>
+        <th>Dims Mapping (JSON)</th>
+        <th>Coords Mapping (JSON)</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <button id='combine-btn'>Combine Selected</button>
+
+  <h3>Dataset Preview</h3>
+  <div id='dataset-output'></div>
+
+  <script src='static/js/main.js'></script>
+</body>
+</html>

--- a/AFL/double_agent/driver_templates/dataset_builder/js/main.js
+++ b/AFL/double_agent/driver_templates/dataset_builder/js/main.js
@@ -1,0 +1,88 @@
+async function loadPlugins() {
+  const res = await fetch('/plugin_list');
+  if (!res.ok) return [];
+  return await res.json();
+}
+
+let plugins = [];
+
+function createPluginSelect() {
+  const sel = document.createElement('select');
+  sel.className = 'plugin-select';
+  plugins.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p;
+    opt.textContent = p;
+    sel.appendChild(opt);
+  });
+  return sel;
+}
+
+function addFiles() {
+  const files = document.getElementById('file-input').files;
+  const tbody = document.querySelector('#file-table tbody');
+  for (const file of files) {
+    const tr = document.createElement('tr');
+    tr.file = file;
+    const selectTd = document.createElement('td');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'row-select';
+    selectTd.appendChild(checkbox);
+    const nameTd = document.createElement('td');
+    nameTd.textContent = file.name;
+    const pluginTd = document.createElement('td');
+    pluginTd.appendChild(createPluginSelect());
+    const dimsTd = document.createElement('td');
+    const dimsInput = document.createElement('input');
+    dimsInput.type = 'text';
+    dimsInput.placeholder = '{"old_dim": "new_dim"}';
+    dimsInput.className = 'dims-input';
+    dimsTd.appendChild(dimsInput);
+    const coordsTd = document.createElement('td');
+    const coordsInput = document.createElement('input');
+    coordsInput.type = 'text';
+    coordsInput.placeholder = '{"coord": [1,2]}';
+    coordsInput.className = 'coords-input';
+    coordsTd.appendChild(coordsInput);
+
+    tr.appendChild(selectTd);
+    tr.appendChild(nameTd);
+    tr.appendChild(pluginTd);
+    tr.appendChild(dimsTd);
+    tr.appendChild(coordsTd);
+
+    tbody.appendChild(tr);
+  }
+}
+
+async function combineSelected() {
+  const rows = document.querySelectorAll('#file-table tbody tr');
+  for (const row of rows) {
+    const cb = row.querySelector('.row-select');
+    if (!cb.checked) continue;
+    const file = row.file;
+    const plugin = row.querySelector('.plugin-select').value;
+    const dims = row.querySelector('.dims-input').value || '{}';
+    const coords = row.querySelector('.coords-input').value || '{}';
+    const buf = await file.arrayBuffer();
+    const bytes = Array.from(new Uint8Array(buf));
+    await fetch('/upload_data', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({plugin, filename: file.name, file_bytes: bytes, dims, coords})
+    });
+  }
+
+  const res = await fetch('/get_dataset_html');
+  if (res.ok) {
+    const html = await res.text();
+    document.getElementById('dataset-output').innerHTML = html;
+  }
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  plugins = await loadPlugins();
+  document.getElementById('add-files-btn').addEventListener('click', addFiles);
+  document.getElementById('combine-btn').addEventListener('click', combineSelected);
+});

--- a/docs/source/how-to/dataset_builder.rst
+++ b/docs/source/how-to/dataset_builder.rst
@@ -1,0 +1,30 @@
+Using the Dataset Builder
+=========================
+
+The Dataset Builder is a lightweight web application that allows you to upload
+local data files and combine them into an ``xarray.Dataset``.  It is served by
+the :class:`AFL.double_agent.DatasetBuilderDriver`.
+
+Usage
+-----
+
+1. Start the driver::
+
+     python -m AFL.double_agent.DatasetBuilderDriver
+
+2. Open ``http://localhost:5051/dataset_builder`` in your browser.
+
+3. Add a series of files using the **Add Files** button. Each row in the table
+   allows you to choose the loader plugin, rename dimensions and specify
+   coordinates.
+
+4. Tick the files you wish to combine and press **Combine Selected**.  The
+   resulting ``xarray.Dataset`` will be rendered on the page using its HTML
+   representation.
+
+Plugins
+-------
+
+Loader plugins provide support for different file formats.  The driver ships
+with loaders for NumPy, pandas CSV/TSV, NetCDF, and basic SAS formats.  Custom
+loaders can be added by placing new modules in ``AFL.double_agent.dataset_plugins``.

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -12,4 +12,5 @@ Guides for specific tasks
    autosas_modal_selection
    saving_pipelines
    pipeline_builder
+   dataset_builder
 


### PR DESCRIPTION
implement DatasetBuilderDriver with simple file upload and plugin loaders

add dataset loader plugin architecture with numpy, pandas, xarray and sasmodels

create dataset_builder web template with JS frontend

document Dataset Builder and update how-to index

expand dataset builder interface with table for file annotation and dataset preview
