### PR TITLE
Add TensorFlow import guard and update dependencies 

### DIFF
--- a/AFL/double_agent/TensorFlowExtrapolator.py
+++ b/AFL/double_agent/TensorFlowExtrapolator.py
@@ -4,7 +4,10 @@ Extrapolators take discrete sample data and extrapolate the data onto a provided
 This file segments all extapolators that require tensorflow.
 """
 
+import os
+import sys
 from typing import List
+from importlib.metadata import PackageNotFoundError, version
 from typing_extensions import Self
 
 import numpy as np
@@ -13,6 +16,30 @@ import tqdm  # type: ignore
 
 from AFL.double_agent.PipelineOp import PipelineOp
 from AFL.double_agent.util import listify
+
+
+def _tensorflow_import_guard() -> None:
+    """Fail fast on runtimes that are known to crash during tensorflow import."""
+    if os.environ.get("AFL_ALLOW_UNSAFE_TENSORFLOW_IMPORT") == "1":
+        return
+    if sys.version_info < (3, 13):
+        return
+
+    try:
+        tf_version = version("tensorflow")
+    except PackageNotFoundError:
+        tf_version = "not installed"
+
+    raise ImportError(
+        "TensorFlowExtrapolator is disabled on Python "
+        f"{sys.version_info.major}.{sys.version_info.minor}; "
+        f"installed tensorflow={tf_version} is not stable in this runtime. "
+        "Use Python 3.11 or 3.12 for tensorflow-backed ops, or set "
+        "AFL_ALLOW_UNSAFE_TENSORFLOW_IMPORT=1 to bypass this guard."
+    )
+
+
+_tensorflow_import_guard()
 
 import tensorflow as tf  # type: ignore
 import gpflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ graph = [
 ]
 
 tensorflow = [
-    "tensorflow>=2.18",
-    "gpflow",
+    "tensorflow>=2.18; python_version < '3.13'",
+    "gpflow; python_version < '3.13'",
 ]
 
 pytorch = [
@@ -126,8 +126,8 @@ all = [
     "ipympl",
     "nodejs",
     # "pygraphviz", #leave out, breaks documentation build
-    "tensorflow>=2.18",
-    "gpflow",
+    "tensorflow>=2.18; python_version < '3.13'",
+    "gpflow; python_version < '3.13'",
     "torch",
     "torchvision",
     "flask<2.3",

--- a/tests/test_agentdriver_pipeline_ops.py
+++ b/tests/test_agentdriver_pipeline_ops.py
@@ -1,3 +1,7 @@
+import importlib
+import importlib.metadata
+import pathlib
+import sys
 from types import SimpleNamespace
 
 import numpy as np
@@ -99,6 +103,45 @@ def test_get_pipeline_ops_strict_skips_cache(monkeypatch):
     assert result["ops"] == [{"name": "FreshStrict"}]
     assert result["cache"]["source"] == "fresh"
     assert call_count["count"] == 1
+
+
+def test_collect_pipeline_ops_skips_unsupported_tensorflow_module(monkeypatch):
+    if sys.version_info < (3, 13):
+        pytest.skip("TensorFlow import guard only applies on Python 3.13+")
+
+    monkeypatch.delenv("AFL_ALLOW_UNSAFE_TENSORFLOW_IMPORT", raising=False)
+    sys.modules.pop("AFL.double_agent.TensorFlowExtrapolator", None)
+    tf_version = importlib.metadata.version("tensorflow")
+
+    module_path = pathlib.Path(agent_driver.__file__).with_name("TensorFlowExtrapolator.py")
+    ops, warnings = agent_driver._collect_pipeline_ops([module_path], strict=False)
+
+    assert ops == []
+    assert warnings == [
+        {
+            "module": "AFL.double_agent.TensorFlowExtrapolator",
+            "stage": "import",
+            "error_type": "ImportError",
+            "message": (
+                "TensorFlowExtrapolator is disabled on Python "
+                f"{sys.version_info.major}.{sys.version_info.minor}; "
+                f"installed tensorflow={tf_version} is not stable in this runtime. "
+                "Use Python 3.11 or 3.12 for tensorflow-backed ops, or set "
+                "AFL_ALLOW_UNSAFE_TENSORFLOW_IMPORT=1 to bypass this guard."
+            ),
+        }
+    ]
+
+
+def test_tensorflow_extrapolator_import_fails_fast_on_unsupported_python(monkeypatch):
+    if sys.version_info < (3, 13):
+        pytest.skip("TensorFlow import guard only applies on Python 3.13+")
+
+    monkeypatch.delenv("AFL_ALLOW_UNSAFE_TENSORFLOW_IMPORT", raising=False)
+    sys.modules.pop("AFL.double_agent.TensorFlowExtrapolator", None)
+
+    with pytest.raises(ImportError, match="TensorFlowExtrapolator is disabled on Python"):
+        importlib.import_module("AFL.double_agent.TensorFlowExtrapolator")
 
 
 def test_double_agent_driver_static_dirs_point_to_apps():


### PR DESCRIPTION
This pull request introduces a compatibility guard to prevent importing TensorFlow-backed extrapolators on unsupported Python versions (3.13 and above), updates dependency specifications accordingly, and adds tests to ensure the new behavior. These changes help avoid runtime crashes due to known incompatibilities between TensorFlow and newer Python versions.

**TensorFlow import guard and compatibility enforcement:**

* Added a `_tensorflow_import_guard` function in `TensorFlowExtrapolator.py` to fail fast with a clear error message when running on Python 3.13+ unless explicitly overridden, preventing unstable TensorFlow imports.
* Updated dependency specifications in `pyproject.toml` to only install `tensorflow` and `gpflow` on Python versions earlier than 3.13, aligning with the new compatibility guard. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L74-R75) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L129-R130)

**Testing for import guard:**

* Added tests in `test_agentdriver_pipeline_ops.py` to verify that TensorFlow-backed modules are skipped and raise informative errors on unsupported Python versions, ensuring robust behavior and clear user feedback.

**Code maintenance:**

* Added necessary imports in `TensorFlowExtrapolator.py` and `test_agentdriver_pipeline_ops.py` to support the new guard and tests. [[1]](diffhunk://#diff-d86a7b308948aa4de99113ce87a948f8bc54725d3ff46f517f4bf50e7864b740R7-R10) [[2]](diffhunk://#diff-5d308d816b31993fc45bf1ce512c457a94ed0ac7d765d0b361df50ba3590aa18R1-R4)